### PR TITLE
Add caching of parsed fixtures

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace IW\PHPUnit\DbFixtures;
+
+class Cache
+{
+    private static $instance;
+    private $data = [];
+
+    private function __construct() {}
+
+    public static function getInstance() {
+        if (self::$instance === null) {
+            self::$instance = new self;
+        }
+
+        return self::$instance;
+    }
+
+    public function has($key) {
+        return array_key_exists($key, $this->data);
+    }
+
+    public function get($key) {
+        return $this->data[$key];
+    }
+
+    public function set($key, $data) {
+        $this->data[$key] = $data;
+    }
+}


### PR DESCRIPTION
This pull request introduce a singleton cache for all parsed fixtures. I personally not so happy about using singleton for this, but it allows too hold all parsed fixtures in memory even across multiple test cases.

What's your opinion on this change?