### PR TITLE
Add docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:7.4-cli
+
+RUN apt-get update
+RUN apt-get install -y autoconf pkg-config libssl-dev libonig-dev libzip-dev
+RUN pecl install mongodb
+RUN docker-php-ext-install pdo_mysql mbstring zip opcache
+RUN echo "extension=mongodb.so" >> /usr/local/etc/php/conf.d/mongodb.ini
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer

--- a/tests/UsageOfDbFixturesTraitTest.php
+++ b/tests/UsageOfDbFixturesTraitTest.php
@@ -12,9 +12,14 @@ final class UsageOfDbFixturesTraitTest extends \PHPUnit\Framework\TestCase
     private $sqlite;
 
     protected function getConnections(): array {
+        $mysqlServer = getenv('MYSQL_SERVER') !== false ? getenv('MYSQL_SERVER') : '127.0.0.1';
+        $mysqlPort   = getenv('MYSQL_PORT') !== false ? getenv('MYSQL_PORT') : '33060';
+
+        $mongoServer = getenv('MONGO_SERVER') !== false ? getenv('MONGO_SERVER') : '127.0.0.1';
+        $mongoPort   = getenv('MONGO_PORT') !== false ? getenv('MONGO_PORT') : '27016';
         return [
             'mysql' => $this->mysql ?? $this->mysql = new \PDO(
-                'mysql:host=127.0.0.1:33060;dbname=db',
+                'mysql:host='.$mysqlServer.':'.$mysqlPort.';dbname=db',
                 'root',
                 '',
                 [
@@ -30,7 +35,7 @@ final class UsageOfDbFixturesTraitTest extends \PHPUnit\Framework\TestCase
                 ]
             ),
             'mongo' => $this->mongo ?? $this->mongo = (new Client(
-                'mongodb://127.0.0.1:27016/db'
+                'mongodb://'.$mongoServer.':'.$mongoPort.'/db'
                 ))->selectDatabase('db')
         ];
     }


### PR DESCRIPTION
This can be a subject of controversy as this pull request introduce a docker image which can be used for running unit tests without need to have a mongdb extension turn on on local enviroment. After image build unit tests can be run by command:

`docker run -e MYSQL_SERVER=mysql -e MYSQL_PORT=3306 -e MONGO_SERVER=mongo -e MONGO_PORT=27017  -v $(pwd):$(pwd) -it -w $(pwd) --network=phpunit-db-fixtures_default phpunittrait vendor/bin/phpunit`

